### PR TITLE
Update version colorama and python-vagrant

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,11 @@
-colorama==0.3.6
+colorama==0.3.7
 docopt==0.6.2
 Jinja2>=2.8
 paramiko
 pbr
 pexpect==4.0.1
 PrettyTable==0.7.2
-python-vagrant==0.5.10
+python-vagrant==0.5.11
 PyYAML==3.11
 sh==1.11
 testinfra


### PR DESCRIPTION
According to https://requires.io/github/rgreinho/molecule/requirements/?branch=master, colorama and python-vagrant modules are outdated. Evaluating the changelog of each respective modules (2 bug fixes and 1 feature add), seems risk free and no behaviour changes are expected.
